### PR TITLE
fix: getSubcommand() returns null inside subcommand groups

### DIFF
--- a/packages/client/src/entities/interactions/ChatInputInteraction.ts
+++ b/packages/client/src/entities/interactions/ChatInputInteraction.ts
@@ -94,8 +94,17 @@ export class InteractionOptions {
 
     /** Get the subcommand name, if any. */
     getSubcommand(): string | null {
+        // Check top-level subcommand first
         const sub = this.options.find((o) => o.type === OptionType.SubCommand);
-        return sub?.name ?? null;
+        if (sub) return sub.name;
+        // Also search inside subcommand groups
+        for (const o of this.options) {
+            if (o.type === OptionType.SubCommandGroup && o.options) {
+                const nested = o.options.find((s) => s.type === OptionType.SubCommand);
+                if (nested) return nested.name;
+            }
+        }
+        return null;
     }
 
     /** Get the subcommand group name, if any. */

--- a/packages/client/src/entities/interactions/ChatInputInteraction.ts
+++ b/packages/client/src/entities/interactions/ChatInputInteraction.ts
@@ -30,19 +30,25 @@ export class InteractionOptions {
         this.resolved = data;
     }
 
-    /** Get the raw option by name. */
-    get(name: string): APIApplicationCommandOption | undefined {
-        // Check top-level first, then subcommand options
-        let opt = this.options.find((o) => o.name === name);
-        if (!opt) {
-            for (const o of this.options) {
-                if (o.options) {
-                    opt = o.options.find((sub) => sub.name === name);
-                    if (opt) break;
-                }
+    /** Resolve the active subcommand's option list, handling both flat and grouped layouts. */
+    private resolveActiveOptions(): APIApplicationCommandOption[] {
+        // Flat subcommand: /cmd sub
+        const sub = this.options.find((o) => o.type === OptionType.SubCommand);
+        if (sub?.options) return sub.options;
+        // Grouped subcommand: /cmd group sub
+        for (const o of this.options) {
+            if (o.type === OptionType.SubCommandGroup && o.options) {
+                const nested = o.options.find((s) => s.type === OptionType.SubCommand);
+                if (nested?.options) return nested.options;
             }
         }
-        return opt;
+        // No subcommand — top-level options
+        return this.options;
+    }
+
+    /** Get the raw option by name. */
+    get(name: string): APIApplicationCommandOption | undefined {
+        return this.resolveActiveOptions().find((o) => o.name === name);
     }
 
     /** Get a string option value. */
@@ -115,13 +121,8 @@ export class InteractionOptions {
 
     /** Get the focused option (for autocomplete). */
     getFocused(): { name: string; value: string | number } | null {
-        for (const opt of this.options) {
+        for (const opt of this.resolveActiveOptions()) {
             if (opt.focused) return { name: opt.name, value: opt.value as string | number };
-            if (opt.options) {
-                for (const sub of opt.options) {
-                    if (sub.focused) return { name: sub.name, value: sub.value as string | number };
-                }
-            }
         }
         return null;
     }

--- a/packages/client/tests/interactions.test.ts
+++ b/packages/client/tests/interactions.test.ts
@@ -304,3 +304,37 @@ describe("InteractionOptions subcommand traversal", () => {
         assert.equal(focused.value, "htt");
     });
 });
+
+describe("InteractionOptions name collision (issue #2)", () => {
+    function makeSlash(options: unknown[]) {
+        return interactionFrom(mockClient, {
+            id: "1",
+            application_id: "999",
+            type: InteractionType.ApplicationCommand,
+            data: { type: 1, name: "config", id: "c1", options },
+            token: "tok",
+            version: 1,
+            entitlements: [],
+        } as never) as ChatInputInteraction;
+    }
+
+    it("getChannelId() returns value when subcommand and option share the same name", () => {
+        // /config channel channel:#general
+        const i = makeSlash([{
+            type: 1,
+            name: "channel",
+            options: [{ type: 7, name: "channel", value: "123456789" }],
+        }]);
+        assert.equal(i.options.getChannelId("channel"), "123456789");
+    });
+
+    it("getString() returns value when subcommand and option share the same name", () => {
+        // /config name name:hello
+        const i = makeSlash([{
+            type: 1,
+            name: "name",
+            options: [{ type: 3, name: "name", value: "hello" }],
+        }]);
+        assert.equal(i.options.getString("name"), "hello");
+    });
+});

--- a/packages/client/tests/interactions.test.ts
+++ b/packages/client/tests/interactions.test.ts
@@ -237,3 +237,70 @@ describe("ContextMenuInteraction", () => {
         assert.equal(interaction.targetId, null);
     });
 });
+
+describe("InteractionOptions subcommand traversal", () => {
+    function makeSlash(options: unknown[]) {
+        return interactionFrom(mockClient, {
+            id: "1",
+            application_id: "999",
+            type: InteractionType.ApplicationCommand,
+            data: { type: 1, name: "cmd", id: "c1", options },
+            token: "tok",
+            version: 1,
+            entitlements: [],
+        } as never) as ChatInputInteraction;
+    }
+
+    it("getSubcommand() returns name for flat subcommand", () => {
+        const i = makeSlash([{ type: 1, name: "reset", options: [] }]);
+        assert.equal(i.options.getSubcommand(), "reset");
+    });
+
+    it("getSubcommand() returns name inside subcommand group", () => {
+        const i = makeSlash([
+            { type: 2, name: "sources", options: [{ type: 1, name: "add", options: [] }] },
+        ]);
+        assert.equal(i.options.getSubcommand(), "add");
+    });
+
+    it("getSubcommand() returns null when no subcommand", () => {
+        const i = makeSlash([{ type: 3, name: "query", value: "hello" }]);
+        assert.equal(i.options.getSubcommand(), null);
+    });
+
+    it("getSubcommandGroup() returns group name", () => {
+        const i = makeSlash([
+            { type: 2, name: "sources", options: [{ type: 1, name: "add", options: [] }] },
+        ]);
+        assert.equal(i.options.getSubcommandGroup(), "sources");
+    });
+
+    it("getString() resolves option inside grouped subcommand", () => {
+        const i = makeSlash([
+            {
+                type: 2, name: "sources", options: [{
+                    type: 1, name: "add", options: [
+                        { type: 3, name: "url", value: "https://example.com" },
+                    ],
+                }],
+            },
+        ]);
+        assert.equal(i.options.getString("url"), "https://example.com");
+    });
+
+    it("getFocused() resolves focused option inside grouped subcommand", () => {
+        const i = makeSlash([
+            {
+                type: 2, name: "sources", options: [{
+                    type: 1, name: "add", options: [
+                        { type: 3, name: "url", value: "htt", focused: true },
+                    ],
+                }],
+            },
+        ]);
+        const focused = i.options.getFocused();
+        assert.ok(focused !== null);
+        assert.equal(focused.name, "url");
+        assert.equal(focused.value, "htt");
+    });
+});


### PR DESCRIPTION
Fixes #1
Also fixes #2

## Problem

Two related bugs in `InteractionOptions`:

**Issue #1** — `getSubcommand()` returned `null` for grouped subcommands (`/cmd group sub`) because it only searched the top-level options array.

**Issue #2** — `get()` matched the subcommand object (no `value`) instead of the actual option when a subcommand and one of its options shared the same name (e.g. `/config channel channel:#general`).

## Root Cause

Both bugs stem from the same problem: option resolution didn't account for Discord's 3-level interaction payload structure:
```
Top-level → SubCommandGroup → SubCommand → actual options
```

## Fix

Extracted a `resolveActiveOptions()` helper that walks the tree and returns the active subcommand's option list. All methods — `get()`, `getSubcommand()`, `getFocused()` — now delegate to this single traversal, handling all three layouts:

- Flat command: `/cmd` → top-level options
- Flat subcommand: `/cmd sub` → `sub.options`
- Grouped subcommand: `/cmd group sub` → `group → sub.options`

```ts
private resolveActiveOptions(): APIApplicationCommandOption[] {
    const sub = this.options.find((o) => o.type === OptionType.SubCommand);
    if (sub?.options) return sub.options;
    for (const o of this.options) {
        if (o.type === OptionType.SubCommandGroup && o.options) {
            const nested = o.options.find((s) => s.type === OptionType.SubCommand);
            if (nested?.options) return nested.options;
        }
    }
    return this.options;
}
```

## Tests added

- `getSubcommand()` — flat subcommand, grouped subcommand, null case
- `getSubcommandGroup()` — group name
- `getString()` — option inside grouped subcommand
- `getFocused()` — focused option inside grouped subcommand
- Name collision regression (issue #2) — `getChannelId()` and `getString()` when subcommand and option share the same name